### PR TITLE
Pagination with database and remote resources using Flow

### DIFF
--- a/code/app/build.gradle.kts
+++ b/code/app/build.gradle.kts
@@ -85,6 +85,8 @@ dependencies {
     implementation(Dependencies.Jetpack.Room.coroutines)
     ksp(Dependencies.Jetpack.Room.ksp)
 
+    implementation(Dependencies.Kotlin.coroutines)
+
     // region [ Test dependencies ]
     testImplementation(Dependencies.JUnit.junit)
     androidTestImplementation(Dependencies.Test.Ext.junit)

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/data/dao/PokemonDao.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/data/dao/PokemonDao.kt
@@ -10,18 +10,21 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 
 @Dao
-abstract class PokemonDao {
+interface PokemonDao {
     @Transaction
     @Query("""
         SELECT * FROM Pokemon
         WHERE number > :cursor AND number < (:cursor + :offset + 1)
         LIMIT :offset
     """)
-    abstract fun getPokemonWithType(cursor: Int = 0, offset: Int): Flow<List<PokemonTypePair>>
+    fun getPokemonWithType(cursor: Int = 0, offset: Int): Flow<List<PokemonTypePair>>
+
+    @Query("SELECT COUNT(1) FROM Pokemon")
+    suspend fun count(): Int
 
     @Insert
-    abstract suspend fun insert(pokemon: Pokemon): Long
+    suspend fun insert(pokemon: Pokemon): Long
 
     @Insert
-    abstract suspend fun insertAll(pokemonList: List<Pokemon>)
+    suspend fun insertAll(pokemonList: List<Pokemon>)
 }

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/data/dao/PokemonDao.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/data/dao/PokemonDao.kt
@@ -12,15 +12,16 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 @Dao
 abstract class PokemonDao {
     @Transaction
-    @Query("SELECT * FROM Pokemon")
-    abstract fun getPokemonWithType(): Flow<List<PokemonTypePair>>
+    @Query("""
+        SELECT * FROM Pokemon
+        WHERE number > :cursor AND number < (:cursor + :offset + 1)
+        LIMIT :offset
+    """)
+    abstract fun getPokemonWithType(cursor: Int = 0, offset: Int): Flow<List<PokemonTypePair>>
 
     @Insert
     abstract suspend fun insert(pokemon: Pokemon): Long
 
     @Insert
     abstract suspend fun insertAll(pokemonList: List<Pokemon>)
-
-    fun getPokemonWithTypeDistinctUntilChanged() =
-        getPokemonWithType().distinctUntilChanged()
 }

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/data/remote/responses/PokemonList.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/data/remote/responses/PokemonList.kt
@@ -2,7 +2,7 @@ package dev.tonholo.study.pokedex.data.remote.responses
 
 data class PokemonList(
     val count: Int,
-    val next: String,
-    val previous: String,
+    val next: String? = null,
+    val previous: String? = null,
     val results: List<PokemonListResult>,
 )

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/data/remote/responses/PokemonListResult.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/data/remote/responses/PokemonListResult.kt
@@ -4,4 +4,5 @@ package dev.tonholo.study.pokedex.data.remote.responses
 data class PokemonListResult(
     val name: String,
     val url: String,
+    val number: Int? = null,
 )

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/PokemonListScreen.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/PokemonListScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -21,24 +20,25 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import coil.annotation.ExperimentalCoilApi
 import dev.tonholo.study.pokedex.R
-import dev.tonholo.study.pokedex.data.dao.PokemonDao
-import dev.tonholo.study.pokedex.data.entity.PokemonTypePair
 import dev.tonholo.study.pokedex.data.remote.PokeApi
 import dev.tonholo.study.pokedex.data.remote.responses.Pokemon
 import dev.tonholo.study.pokedex.data.remote.responses.PokemonList
 import dev.tonholo.study.pokedex.data.remote.responses.PokemonListResult
 import dev.tonholo.study.pokedex.screens.pokemonList.components.PokemonList
 import dev.tonholo.study.pokedex.screens.pokemonList.components.SearchBar
+import dev.tonholo.study.pokedex.screens.util.preview.stubs.StubPokemonDao
 import dev.tonholo.study.pokedex.ui.theme.PokedexAppThemePreview
 import dev.tonholo.study.pokedex.ui.theme.state.ThemeState
 import dev.tonholo.study.pokedex.ui.theme.state.ThemeStateHandler
 import dev.tonholo.study.pokedex.ui.theme.viewModel.ThemeViewModel
 import dev.tonholo.study.pokedex.usecases.CachePokemonListUseCase
-import dev.tonholo.study.pokedex.usecases.GetPokemonListUseCase
-import kotlinx.coroutines.flow.Flow
+import dev.tonholo.study.pokedex.usecases.GetPokemonListFromDatabaseUseCase
+import dev.tonholo.study.pokedex.usecases.GetPokemonListFromRemoteUseCase
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
+@FlowPreview
 @ExperimentalCoilApi
 @Composable
 fun PokemonListScreen(
@@ -91,6 +91,7 @@ fun PokemonListScreen(
     }
 }
 
+@FlowPreview
 @ExperimentalCoilApi
 @Preview
 @Composable
@@ -105,6 +106,7 @@ private fun LightThemePreview() {
     }
 }
 
+@FlowPreview
 @ExperimentalCoilApi
 @Preview(
     showBackground = true,
@@ -138,6 +140,7 @@ private fun buildPreviewThemeViewModel(themeState: ThemeState) =
         }
     )
 
+@FlowPreview
 private fun buildFakeViewModel(): PokemonListViewModel {
     val entries = (0..100).map {
         PokemonListResult(
@@ -146,9 +149,8 @@ private fun buildFakeViewModel(): PokemonListViewModel {
         )
     }
 
-
     return PokemonListViewModel(
-        GetPokemonListUseCase(object : PokeApi {
+        GetPokemonListFromRemoteUseCase(object : PokeApi {
             override suspend fun getPokemonList(limit: Int, offset: Int): PokemonList = with(entries) {
                 PokemonList(
                     count = size,
@@ -162,18 +164,7 @@ private fun buildFakeViewModel(): PokemonListViewModel {
                 TODO("Not yet implemented")
             }
         }),
-        CachePokemonListUseCase(object : PokemonDao() {
-            override fun getPokemonWithType(): Flow<List<PokemonTypePair>> {
-                TODO("Not yet implemented")
-            }
-
-            override suspend fun insert(pokemon: dev.tonholo.study.pokedex.data.entity.Pokemon): Long {
-                TODO("Not yet implemented")
-            }
-
-            override suspend fun insertAll(pokemonList: List<dev.tonholo.study.pokedex.data.entity.Pokemon>) {
-                TODO("Not yet implemented")
-            }
-        })
+        GetPokemonListFromDatabaseUseCase(StubPokemonDao),
+        CachePokemonListUseCase(StubPokemonDao),
     )
 }

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/PokemonListScreen.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/PokemonListScreen.kt
@@ -34,11 +34,9 @@ import dev.tonholo.study.pokedex.ui.theme.viewModel.ThemeViewModel
 import dev.tonholo.study.pokedex.usecases.CachePokemonListUseCase
 import dev.tonholo.study.pokedex.usecases.GetPokemonListFromDatabaseUseCase
 import dev.tonholo.study.pokedex.usecases.GetPokemonListFromRemoteUseCase
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
-@FlowPreview
 @ExperimentalCoilApi
 @Composable
 fun PokemonListScreen(
@@ -91,7 +89,6 @@ fun PokemonListScreen(
     }
 }
 
-@FlowPreview
 @ExperimentalCoilApi
 @Preview
 @Composable
@@ -106,7 +103,6 @@ private fun LightThemePreview() {
     }
 }
 
-@FlowPreview
 @ExperimentalCoilApi
 @Preview(
     showBackground = true,
@@ -140,7 +136,6 @@ private fun buildPreviewThemeViewModel(themeState: ThemeState) =
         }
     )
 
-@FlowPreview
 private fun buildFakeViewModel(): PokemonListViewModel {
     val entries = (0..100).map {
         PokemonListResult(

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/PokemonListViewModel.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/PokemonListViewModel.kt
@@ -3,26 +3,35 @@ package dev.tonholo.study.pokedex.screens.pokemonList
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
+import android.util.Log
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.tonholo.study.pokedex.data.model.PokemonEntry
-import dev.tonholo.study.pokedex.usecases.CachePokemonDetailUseCase
 import dev.tonholo.study.pokedex.usecases.CachePokemonListUseCase
-import dev.tonholo.study.pokedex.usecases.GetPokemonListUseCase
+import dev.tonholo.study.pokedex.usecases.GetPokemonListFromDatabaseUseCase
+import dev.tonholo.study.pokedex.usecases.GetPokemonListFromRemoteUseCase
+import dev.tonholo.study.pokedex.util.Resource
 import dev.tonholo.study.pokedex.util.toTitleCase
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import java.util.*
 import javax.inject.Inject
 
-const val PAGE_SIZE = 20
+private const val PAGE_SIZE = 20
+private const val TAG = "PokemonListViewModel"
 
+@FlowPreview
 @HiltViewModel
 class PokemonListViewModel @Inject constructor(
-    val getPokemonListUseCase: GetPokemonListUseCase,
+    val getPokemonListFromRemoteUseCase: GetPokemonListFromRemoteUseCase,
+    val getPokemonListFromDatabaseUseCase: GetPokemonListFromDatabaseUseCase,
     val cachePokemonListUseCase: CachePokemonListUseCase,
 ) : ViewModel() {
     private var currentPage = 0
@@ -40,15 +49,90 @@ class PokemonListViewModel @Inject constructor(
     }
 
     fun loadPokemonListPaginated() {
+        Log.d(TAG, "loadPokemonListPaginated() called")
+        Log.d(TAG, "loadPokemonListPaginated: currentPage = $currentPage")
+        Log.d(TAG, "loadPokemonListPaginated: pokemonList.size = ${pokemonList.value.size}")
+        Log.d(TAG, "loadPokemonListPaginated: isEndReached = $isEndReached")
+        Log.d(TAG, "loadPokemonListPaginated: isSearching = $isSearching")
+
+        val offset = PAGE_SIZE
+        val cursor = currentPage * PAGE_SIZE
         viewModelScope.launch {
-            isLoading.value = true
-            val params = GetPokemonListUseCase.Params(
+            getPokemonListFromDatabaseUseCase(GetPokemonListFromDatabaseUseCase.Params(
+                cursor = cursor,
+                offset = offset,
+            ))
+                .map(::mapFromDatabase)
+                .map(::mapFromRemote)
+                .map(::cacheRemoteResponse)
+                .distinctUntilChanged()
+                .collectLatest { resource ->
+                    Log.d(TAG, "collectLatest() called with: resource = $resource")
+                    Log.d(TAG, "collectLatest: pokemonList.size = ${pokemonList.value.size}")
+                    Log.d(TAG, "collectLatest: currentPage = $currentPage")
+
+                    when (resource) {
+                        is Resource.Error -> {
+                            loadingError.value = "${resource.message}\n${resource.throwable?.localizedMessage}"
+                            isLoading.value = false
+                        }
+                        is Resource.Loading -> isLoading.value = true
+                        is Resource.Success -> {
+                            if (resource.data.isNotEmpty()) {
+                                pokemonList.value += resource.data
+                                isLoading.value = false
+                                currentPage++
+                                Log.d(TAG, "collectLatest: pokemonList.size = ${pokemonList.value.size}")
+                            }
+                        }
+                    }
+                }
+        }
+    }
+
+    private fun mapFromDatabase(result: GetPokemonListFromDatabaseUseCase.Result): Resource<List<PokemonEntry>> {
+        Log.d(TAG, "mapFromDatabase() called with: result = $result")
+        return when (result) {
+            is GetPokemonListFromDatabaseUseCase.Result.Failure ->
+                Resource.Error(result.exception, result.message)
+            GetPokemonListFromDatabaseUseCase.Result.IsLoading -> {
+                Resource.Loading()
+            }
+            is GetPokemonListFromDatabaseUseCase.Result.Success -> {
+                with(result.data.results) {
+                    if (isNotEmpty()) {
+                        Resource.Success(
+                            map { pokemonListResult ->
+                                PokemonEntry(
+                                    pokemonName = pokemonListResult.name,
+                                    imageUrl = pokemonListResult.url,
+                                    number = pokemonListResult.number
+                                        ?: throw Exception("Pokemon number must not  be null coming from database"),
+                                )
+                            }
+                        )
+                    } else {
+                        Resource.Success(emptyList())
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun mapFromRemote(
+        resource: Resource<List<PokemonEntry>>
+    ): Pair<Boolean, Resource<List<PokemonEntry>>> {
+        Log.d(TAG, "mapFromRemote() called with: resource = $resource")
+        return if (resource is Resource.Success && resource.data.isNullOrEmpty()) {
+            val params = GetPokemonListFromRemoteUseCase.Params(
                 limit = PAGE_SIZE,
                 offset = currentPage * PAGE_SIZE,
             )
-
-            when (val result = getPokemonListUseCase(params)) {
-                is GetPokemonListUseCase.Result.Success -> {
+            Log.d(TAG, "mapFromRemote: requesting from remote with: params = $params")
+            when (val result = getPokemonListFromRemoteUseCase(params)) {
+                is GetPokemonListFromRemoteUseCase.Result.Failure ->
+                    (false to Resource.Error(result.exception, result.message))
+                is GetPokemonListFromRemoteUseCase.Result.Success -> {
                     with(result.data) {
                         isEndReached.value = currentPage * PAGE_SIZE >= count
                         val pokedexEntries = result.data.results.map { entry ->
@@ -68,17 +152,36 @@ class PokemonListViewModel @Inject constructor(
                             )
                         }
 
-                        // cachePokemonListUseCase(pokedexEntries)
-                        pokemonList.value += pokedexEntries
+                        (true to Resource.Success(pokedexEntries))
                     }
-                    isLoading.value = false
-                    currentPage++
-                }
-                is GetPokemonListUseCase.Result.Failure -> {
-                    loadingError.value = "${result.message}\n${result.exception?.message}"
-                    isLoading.value = false
                 }
             }
+        } else {
+            Log.d(TAG, "mapFromRemote: emitting database result")
+            (false to resource)
+        }
+    }
+
+    private suspend fun cacheRemoteResponse(
+        pair: Pair<Boolean, Resource<List<PokemonEntry>>>,
+    ): Resource<List<PokemonEntry>> {
+        Log.d(TAG, "cacheRemoteResponse() called with: pair = $pair")
+        val (shouldCacheData, resource) = pair
+        return if (resource is Resource.Success && shouldCacheData) {
+            when (val result = cachePokemonListUseCase(resource.data)) {
+                is CachePokemonListUseCase.Result.Failure -> {
+                    Resource.Error(
+                        throwable = result.exception,
+                        message = result.message,
+                        data = resource.data,
+                    )
+                }
+                is CachePokemonListUseCase.Result.Success -> {
+                    return Resource.Success(emptyList())
+                }
+            }
+        } else {
+            resource
         }
     }
 

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/PokemonListViewModel.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/PokemonListViewModel.kt
@@ -16,7 +16,6 @@ import dev.tonholo.study.pokedex.usecases.GetPokemonListFromRemoteUseCase
 import dev.tonholo.study.pokedex.util.Resource
 import dev.tonholo.study.pokedex.util.toTitleCase
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
@@ -27,7 +26,6 @@ import javax.inject.Inject
 private const val PAGE_SIZE = 20
 private const val TAG = "PokemonListViewModel"
 
-@FlowPreview
 @HiltViewModel
 class PokemonListViewModel @Inject constructor(
     val getPokemonListFromRemoteUseCase: GetPokemonListFromRemoteUseCase,

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/components/PokedexRow.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/components/PokedexRow.kt
@@ -35,9 +35,7 @@ import dev.tonholo.study.pokedex.ui.theme.RobotoCondensed
 import dev.tonholo.study.pokedex.usecases.CachePokemonListUseCase
 import dev.tonholo.study.pokedex.usecases.GetPokemonListFromDatabaseUseCase
 import dev.tonholo.study.pokedex.usecases.GetPokemonListFromRemoteUseCase
-import kotlinx.coroutines.FlowPreview
 
-@FlowPreview
 @ExperimentalCoilApi
 @Composable
 fun PokedexRow(
@@ -70,7 +68,6 @@ fun PokedexRow(
     }
 }
 
-@FlowPreview
 @ExperimentalCoilApi
 @Composable
 private fun PokedexEntry(
@@ -152,7 +149,6 @@ private fun PokedexEntry(
     }
 }
 
-@FlowPreview
 @ExperimentalCoilApi
 @Preview(
     showBackground = true,
@@ -190,7 +186,6 @@ private fun LightThemePreview() {
     }
 }
 
-@FlowPreview
 @ExperimentalCoilApi
 @Preview(
     showBackground = true,

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/components/PokedexRow.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/components/PokedexRow.kt
@@ -25,20 +25,19 @@ import androidx.navigation.compose.rememberNavController
 import coil.annotation.ExperimentalCoilApi
 import coil.compose.ImagePainter
 import coil.compose.rememberImagePainter
-import dev.tonholo.study.pokedex.data.dao.PokemonDao
-import dev.tonholo.study.pokedex.data.entity.PokemonTypePair
 import dev.tonholo.study.pokedex.data.model.PokemonEntry
-import dev.tonholo.study.pokedex.data.remote.PokeApi
-import dev.tonholo.study.pokedex.data.remote.responses.Pokemon
-import dev.tonholo.study.pokedex.data.remote.responses.PokemonList
 import dev.tonholo.study.pokedex.screens.Routes
 import dev.tonholo.study.pokedex.screens.pokemonList.PokemonListViewModel
+import dev.tonholo.study.pokedex.screens.util.preview.stubs.StubPokemonApi
+import dev.tonholo.study.pokedex.screens.util.preview.stubs.StubPokemonDao
 import dev.tonholo.study.pokedex.ui.theme.PokedexAppThemePreview
 import dev.tonholo.study.pokedex.ui.theme.RobotoCondensed
 import dev.tonholo.study.pokedex.usecases.CachePokemonListUseCase
-import dev.tonholo.study.pokedex.usecases.GetPokemonListUseCase
-import kotlinx.coroutines.flow.Flow
+import dev.tonholo.study.pokedex.usecases.GetPokemonListFromDatabaseUseCase
+import dev.tonholo.study.pokedex.usecases.GetPokemonListFromRemoteUseCase
+import kotlinx.coroutines.FlowPreview
 
+@FlowPreview
 @ExperimentalCoilApi
 @Composable
 fun PokedexRow(
@@ -71,6 +70,7 @@ fun PokedexRow(
     }
 }
 
+@FlowPreview
 @ExperimentalCoilApi
 @Composable
 private fun PokedexEntry(
@@ -152,32 +152,7 @@ private fun PokedexEntry(
     }
 }
 
-private object StubPokemonApi : PokeApi {
-    override suspend fun getPokemonList(limit: Int, offset: Int): PokemonList {
-        throw NotImplementedError()
-    }
-
-    override suspend fun getPokemon(name: String): Pokemon {
-        throw NotImplementedError()
-    }
-
-}
-
-private object StubPokemonDao : PokemonDao() {
-    override fun getPokemonWithType(): Flow<List<PokemonTypePair>> {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun insert(pokemon: dev.tonholo.study.pokedex.data.entity.Pokemon): Long {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun insertAll(pokemonList: List<dev.tonholo.study.pokedex.data.entity.Pokemon>) {
-        TODO("Not yet implemented")
-    }
-
-}
-
+@FlowPreview
 @ExperimentalCoilApi
 @Preview(
     showBackground = true,
@@ -205,7 +180,8 @@ private fun LightThemePreview() {
                     entries = entries,
                     navController = navController,
                     viewModel = PokemonListViewModel(
-                        GetPokemonListUseCase(StubPokemonApi),
+                        GetPokemonListFromRemoteUseCase(StubPokemonApi),
+                        GetPokemonListFromDatabaseUseCase(StubPokemonDao),
                         CachePokemonListUseCase(StubPokemonDao),
                     ),
                 )
@@ -214,6 +190,7 @@ private fun LightThemePreview() {
     }
 }
 
+@FlowPreview
 @ExperimentalCoilApi
 @Preview(
     showBackground = true,
@@ -246,7 +223,8 @@ private fun DarkThemePreview() {
                     entries = entries,
                     navController = navController,
                     viewModel = PokemonListViewModel(
-                        GetPokemonListUseCase(StubPokemonApi),
+                        GetPokemonListFromRemoteUseCase(StubPokemonApi),
+                        GetPokemonListFromDatabaseUseCase(StubPokemonDao),
                         CachePokemonListUseCase(StubPokemonDao),
                     ),
                 )

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/components/PokemonList.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/components/PokemonList.kt
@@ -7,7 +7,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -16,9 +18,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import coil.annotation.ExperimentalCoilApi
 import dev.tonholo.study.pokedex.screens.pokemonList.PokemonListViewModel
-import kotlinx.coroutines.FlowPreview
 
-@FlowPreview
 @ExperimentalCoilApi
 @Composable
 fun PokemonList(

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/components/PokemonList.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/components/PokemonList.kt
@@ -10,12 +10,15 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import coil.annotation.ExperimentalCoilApi
 import dev.tonholo.study.pokedex.screens.pokemonList.PokemonListViewModel
+import kotlinx.coroutines.FlowPreview
 
+@FlowPreview
 @ExperimentalCoilApi
 @Composable
 fun PokemonList(
@@ -61,7 +64,9 @@ fun PokemonList(
 
         if (loadError.isNotBlank()) {
             Text(
-                loadError
+                text = loadError,
+                color = Color.Red,
+                style = MaterialTheme.typography.body2,
             )
         }
     }

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/screens/util/preview/stubs/StubPokemonApi.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/screens/util/preview/stubs/StubPokemonApi.kt
@@ -1,0 +1,15 @@
+package dev.tonholo.study.pokedex.screens.util.preview.stubs
+
+import dev.tonholo.study.pokedex.data.remote.PokeApi
+import dev.tonholo.study.pokedex.data.remote.responses.Pokemon
+import dev.tonholo.study.pokedex.data.remote.responses.PokemonList
+
+object StubPokemonApi : PokeApi {
+    override suspend fun getPokemonList(limit: Int, offset: Int): PokemonList {
+        throw NotImplementedError()
+    }
+
+    override suspend fun getPokemon(name: String): Pokemon {
+        throw NotImplementedError()
+    }
+}

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/screens/util/preview/stubs/StubPokemonDao.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/screens/util/preview/stubs/StubPokemonDao.kt
@@ -1,0 +1,23 @@
+package dev.tonholo.study.pokedex.screens.util.preview.stubs
+
+import dev.tonholo.study.pokedex.data.dao.PokemonDao
+import dev.tonholo.study.pokedex.data.entity.PokemonTypePair
+import kotlinx.coroutines.flow.Flow
+
+object StubPokemonDao : PokemonDao {
+    override fun getPokemonWithType(cursor: Int, offset: Int): Flow<List<PokemonTypePair>> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun count(): Int {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun insert(pokemon: dev.tonholo.study.pokedex.data.entity.Pokemon): Long {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun insertAll(pokemonList: List<dev.tonholo.study.pokedex.data.entity.Pokemon>) {
+        TODO("Not yet implemented")
+    }
+}

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/usecases/GetPokemonListFromDatabaseUseCase.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/usecases/GetPokemonListFromDatabaseUseCase.kt
@@ -1,0 +1,56 @@
+package dev.tonholo.study.pokedex.usecases
+
+import android.util.Log
+import dev.tonholo.study.pokedex.data.dao.PokemonDao
+import dev.tonholo.study.pokedex.data.remote.responses.PokemonList
+import dev.tonholo.study.pokedex.data.remote.responses.PokemonListResult
+import dev.tonholo.study.pokedex.usecases.base.UseCaseFlowable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+private const val TAG = "GetPokemonListFromDB"
+
+class GetPokemonListFromDatabaseUseCase @Inject constructor(
+    private val pokemonDao: PokemonDao,
+) : UseCaseFlowable<GetPokemonListFromDatabaseUseCase.Params, GetPokemonListFromDatabaseUseCase.Result>() {
+    data class Params(
+        val cursor: Int = 0,
+        val offset: Int = 0,
+    )
+
+    sealed class Result(open val data: PokemonList? = null) {
+        data class Success(override val data: PokemonList) : Result(data)
+        object IsLoading : Result()
+        data class Failure(val message: String, val exception: Exception? = null) : Result()
+    }
+
+    override fun invoke(requestParams: Params): Flow<Result> = flow {
+        val (cursor, offset) = requestParams
+        emit(Result.IsLoading)
+
+        try {
+            pokemonDao.getPokemonWithType(cursor, offset)
+                .map {
+                    PokemonList(
+                        count = pokemonDao.count(),
+                        results = it.map { (pokemon, _) ->
+                            PokemonListResult(
+                                name = pokemon.name,
+                                url = pokemon.spriteUrl,
+                                number = pokemon.number,
+                            )
+                        }
+                    )
+                }
+                .collect {
+                    emit(Result.Success(it))
+                }
+        } catch (e: Exception) {
+            Log.e(TAG, "invoke: Unknown exception", e)
+            Result.Failure("An unknown error occurred.", e)
+        }
+    }.distinctUntilChanged()
+}

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/usecases/GetPokemonListFromRemoteUseCase.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/usecases/GetPokemonListFromRemoteUseCase.kt
@@ -7,11 +7,11 @@ import dev.tonholo.study.pokedex.usecases.base.UseCase
 import java.lang.Exception
 import javax.inject.Inject
 
-private const val TAG = "GetPokemonListUseCase"
+private const val TAG = "GetPokemonListRemote"
 
-class GetPokemonListUseCase @Inject constructor(
+class GetPokemonListFromRemoteUseCase @Inject constructor(
     private val pokeApi: PokeApi,
-): UseCase<GetPokemonListUseCase.Params, GetPokemonListUseCase.Result>() {
+): UseCase<GetPokemonListFromRemoteUseCase.Params, GetPokemonListFromRemoteUseCase.Result>() {
     data class Params(
         val limit: Int = 0,
         val offset: Int = 0,

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/usecases/base/UseCase.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/usecases/base/UseCase.kt
@@ -1,5 +1,11 @@
 package dev.tonholo.study.pokedex.usecases.base
 
+import kotlinx.coroutines.flow.Flow
+
 abstract class UseCase<in TRequest, out TResponse> {
     abstract suspend operator fun invoke(requestParams: TRequest): TResponse
+}
+
+abstract class UseCaseFlowable<in TRequest, out TResponse> {
+    abstract operator fun invoke(requestParams: TRequest): Flow<TResponse>
 }

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/util/Resource.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/util/Resource.kt
@@ -1,0 +1,11 @@
+package dev.tonholo.study.pokedex.util
+
+sealed class Resource<T>(open val data: T? = null) {
+    data class Success<T>(override val data: T) : Resource<T>(data)
+    data class Loading<T>(override val data: T? = null) : Resource<T>(data)
+    data class Error<T>(
+        val throwable: Throwable?,
+        val message: String,
+        override val data: T? = null,
+    ) : Resource<T>(data)
+}

--- a/code/buildSrc/src/main/java/dev/tonholo/pokedex/buildsrc/Dependencies.kt
+++ b/code/buildSrc/src/main/java/dev/tonholo/pokedex/buildsrc/Dependencies.kt
@@ -18,6 +18,8 @@ object Dependencies {
 
     object Kotlin {
         const val version = "1.5.31"
+        // https://github.com/Kotlin/kotlinx.coroutines/releases
+        const val coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0"
     }
 
     object Material {


### PR DESCRIPTION
# Background
Here is a solution for getting the data, paginated, from the database and if no data are remaining, request more data from remote and cache them.
That PR is part of the #1 issue

# Solution
To achieve the solution it was used Kotlin Coroutine Flow. 
Data are emitted from the database according to the requested page. The flow answer has a chain of operations to check if any data was retrieved from the database and if not, requests from remote.

# Pros
- No change was needed on the UI side

# Cons
- Too much logic in ViewModel, not sure if it should happen. The mapping logic could be abstracted inside another class
- The mapping logic is quite complex. Maybe it is a lack of knowledge, but not sure

# Known bug
Testing the application with no network data and some data already cached, once reached the end of the page, it will continuously request data to remote until it gets network. Once it has network data, it will cache the data but will duplicate the entries on the list for that requested data.

Although the entries in the list became duplicated, the data in the database will not be duplicated.