### PR TITLE
Pagination with database and remote resources using Paging3

### DIFF
--- a/code/app/build.gradle.kts
+++ b/code/app/build.gradle.kts
@@ -83,7 +83,11 @@ dependencies {
 
     implementation(Dependencies.Jetpack.Room.runtime)
     implementation(Dependencies.Jetpack.Room.coroutines)
+    implementation(Dependencies.Jetpack.Room.paging)
     ksp(Dependencies.Jetpack.Room.ksp)
+
+    implementation(Dependencies.Jetpack.Paging.runtime)
+    implementation(Dependencies.Jetpack.Paging.compose)
 
     // region [ Test dependencies ]
     testImplementation(Dependencies.JUnit.junit)

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/data/dao/PokemonDao.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/data/dao/PokemonDao.kt
@@ -21,5 +21,5 @@ interface PokemonDao {
     suspend fun clearAll()
 
     @Query("SELECT MAX(last_update) FROM Pokemon")
-    fun lastUpdated(): Long?
+    suspend fun lastUpdated(): Long?
 }

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/data/dao/PokemonDao.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/data/dao/PokemonDao.kt
@@ -1,26 +1,22 @@
 package dev.tonholo.study.pokedex.data.dao
 
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.Query
-import androidx.room.Transaction
+import androidx.paging.PagingSource
+import androidx.room.*
 import dev.tonholo.study.pokedex.data.entity.Pokemon
 import dev.tonholo.study.pokedex.data.entity.PokemonTypePair
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.distinctUntilChanged
 
 @Dao
-abstract class PokemonDao {
+interface PokemonDao {
     @Transaction
     @Query("SELECT * FROM Pokemon")
-    abstract fun getPokemonWithType(): Flow<List<PokemonTypePair>>
+    fun getPokemonWithType(): PagingSource<Int, PokemonTypePair>
 
     @Insert
-    abstract suspend fun insert(pokemon: Pokemon): Long
+    suspend fun insert(pokemon: Pokemon): Long
 
-    @Insert
-    abstract suspend fun insertAll(pokemonList: List<Pokemon>)
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(pokemonList: List<Pokemon>)
 
-    fun getPokemonWithTypeDistinctUntilChanged() =
-        getPokemonWithType().distinctUntilChanged()
+    @Query("DELETE FROM Pokemon")
+    suspend fun clearAll()
 }

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/data/dao/PokemonDao.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/data/dao/PokemonDao.kt
@@ -14,9 +14,12 @@ interface PokemonDao {
     @Insert
     suspend fun insert(pokemon: Pokemon): Long
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert
     suspend fun insertAll(pokemonList: List<Pokemon>)
 
     @Query("DELETE FROM Pokemon")
     suspend fun clearAll()
+
+    @Query("SELECT MAX(last_update) FROM Pokemon")
+    fun lastUpdated(): Long?
 }

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/data/dao/PokemonWithTypeDao.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/data/dao/PokemonWithTypeDao.kt
@@ -2,10 +2,14 @@ package dev.tonholo.study.pokedex.data.dao
 
 import androidx.room.Dao
 import androidx.room.Insert
+import androidx.room.Query
 import dev.tonholo.study.pokedex.data.entity.PokemonWithType
 
 @Dao
 interface PokemonWithTypeDao {
     @Insert
-    fun insertAll(entities: List<PokemonWithType>)
+    suspend fun insertAll(entities: List<PokemonWithType>)
+
+    @Query("DELETE FROM PokemonWithType")
+    suspend fun clearAll()
 }

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/data/dao/RemoteKeyDao.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/data/dao/RemoteKeyDao.kt
@@ -1,0 +1,19 @@
+package dev.tonholo.study.pokedex.data.dao
+
+import androidx.room.*
+import dev.tonholo.study.pokedex.data.entity.RemoteKey
+
+@Dao
+interface RemoteKeyDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(remoteKeys: RemoteKey)
+
+    @Query("SELECT * FROM RemoteKey WHERE pokemon_number = :pokemonNumber")
+    suspend fun get(pokemonNumber: Int): RemoteKey
+
+    @Query("DELETE FROM RemoteKey WHERE pokemon_number = :pokemonNumber")
+    suspend fun delete(pokemonNumber: Int)
+
+    @Query("DELETE FROM RemoteKey")
+    suspend fun clearAll()
+}

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/data/database/AppDatabase.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/data/database/AppDatabase.kt
@@ -7,9 +7,11 @@ import androidx.room.RoomDatabase
 import dev.tonholo.study.pokedex.data.dao.PokemonDao
 import dev.tonholo.study.pokedex.data.dao.PokemonTypeDao
 import dev.tonholo.study.pokedex.data.dao.PokemonWithTypeDao
+import dev.tonholo.study.pokedex.data.dao.RemoteKeyDao
 import dev.tonholo.study.pokedex.data.entity.Pokemon
 import dev.tonholo.study.pokedex.data.entity.PokemonType
 import dev.tonholo.study.pokedex.data.entity.PokemonWithType
+import dev.tonholo.study.pokedex.data.entity.RemoteKey
 
 private const val DATABASE_NAME = "pokedex_db"
 
@@ -18,6 +20,7 @@ private const val DATABASE_NAME = "pokedex_db"
         Pokemon::class,
         PokemonType::class,
         PokemonWithType::class,
+        RemoteKey::class,
     ],
     version = 1,
     exportSchema = false,
@@ -26,6 +29,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun pokemonDao(): PokemonDao
     abstract fun pokemonTypeDao(): PokemonTypeDao
     abstract fun pokemonWithTypeDao(): PokemonWithTypeDao
+    abstract fun remoteKeyDao(): RemoteKeyDao
 
     companion object {
         operator fun invoke(context: Context) =

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/data/entity/Pokemon.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/data/entity/Pokemon.kt
@@ -21,4 +21,5 @@ data class Pokemon(
     @[Nullable ColumnInfo(name = "special_attack_stat")] val specialAttackStat: Int? = null,
     @[Nullable ColumnInfo(name = "special_defense_stat")] val specialDefenseStat: Int? = null,
     @[Nullable ColumnInfo(name = "speed_stat")] val speedStat: Int? = null,
+    @ColumnInfo(name = "last_update") val lastUpdate: Long = System.currentTimeMillis(),
 )

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/data/entity/RemoteKey.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/data/entity/RemoteKey.kt
@@ -1,0 +1,12 @@
+package dev.tonholo.study.pokedex.data.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity
+data class RemoteKey(
+    @[PrimaryKey ColumnInfo(name = "pokemon_number")]
+    val pokemonNumber: Int,
+    val nextKey: Int?,
+)

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/data/paging/PokemonListRemoteMediator.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/data/paging/PokemonListRemoteMediator.kt
@@ -1,32 +1,60 @@
 package dev.tonholo.study.pokedex.data.paging
 
+import android.util.Log
 import androidx.paging.ExperimentalPagingApi
 import androidx.paging.LoadType
 import androidx.paging.PagingState
 import androidx.paging.RemoteMediator
 import androidx.room.withTransaction
 import dev.tonholo.study.pokedex.data.database.AppDatabase
-import dev.tonholo.study.pokedex.data.model.PokemonEntry
+import dev.tonholo.study.pokedex.data.entity.PokemonTypePair
 import dev.tonholo.study.pokedex.data.remote.PokeApi
-import dev.tonholo.study.pokedex.screens.pokemonList.PAGE_SIZE
 import dev.tonholo.study.pokedex.usecases.CachePokemonListUseCase
-import retrofit2.HttpException
-import java.io.IOException
+import dev.tonholo.study.pokedex.usecases.UpsertRemoteKeyUseCase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
+
+private const val TAG = "RemoteMediator"
+private const val CACHE_TIMEOUT_IN_DAYS = 10L
 
 @ExperimentalPagingApi
 class PokemonListRemoteMediator @Inject constructor(
     private val database: AppDatabase,
     private val pokeApi: PokeApi,
     private val cachePokemonListUseCase: CachePokemonListUseCase,
-) : RemoteMediator<Int, PokemonEntry>() {
+    private val upsertRemoteKeyUseCase: UpsertRemoteKeyUseCase,
+) : RemoteMediator<Int, PokemonTypePair>() {
     private val pokemonDao = database.pokemonDao()
     private val pokemonWithTypeDao = database.pokemonWithTypeDao()
+    private val remoteKeyDao = database.remoteKeyDao()
+
+    override suspend fun initialize(): InitializeAction {
+        val now = System.currentTimeMillis()
+        val lastUpdated = withContext(Dispatchers.IO) {
+            pokemonDao.lastUpdated()
+        } ?: now
+        Log.d(TAG, "initialize: lastUpdated = $lastUpdated")
+        val cacheTimeout = TimeUnit.MILLISECONDS.convert(CACHE_TIMEOUT_IN_DAYS, TimeUnit.DAYS)
+        Log.d(TAG, "initialize: cacheTimeout = $cacheTimeout")
+        return if (now - lastUpdated <= cacheTimeout) {
+            // Cached data is up-to-date, so there is no need to re-fetch from network.
+            InitializeAction.SKIP_INITIAL_REFRESH
+        } else {
+            // Need to refresh cached data from network; returning LAUNCH_INITIAL_REFRESH here
+            // will also block RemoteMediator's APPEND and PREPEND from running until REFRESH
+            // succeeds.
+            InitializeAction.LAUNCH_INITIAL_REFRESH
+        }
+    }
 
     override suspend fun load(
         loadType: LoadType,
-        state: PagingState<Int, PokemonEntry>,
+        state: PagingState<Int, PokemonTypePair>,
     ): MediatorResult {
+        Log.d(TAG, "load() called with: loadType = $loadType, state = $state")
+
         return try {
             val loadKey = when (loadType) {
                 LoadType.REFRESH -> null
@@ -34,35 +62,56 @@ class PokemonListRemoteMediator @Inject constructor(
                     return MediatorResult.Success(endOfPaginationReached = true)
                 LoadType.APPEND -> {
                     val lastItem = state.lastItemOrNull()
-                        ?: return MediatorResult.Success(endOfPaginationReached = true)
-                    lastItem.number
+                        ?: return MediatorResult.Success(endOfPaginationReached = false)
+
+                    Log.d(TAG, "load: lastItem = $lastItem")
+
+                    val remoteKey = database.withTransaction {
+                        remoteKeyDao.get(lastItem.pokemon.number)
+                    }
+
+                    Log.d(TAG, "load: remoteKey = $remoteKey")
+                    remoteKey.nextKey ?: return MediatorResult.Success(endOfPaginationReached = true)
                 }
             }
 
             val response = pokeApi.getPokemonList(
-                limit = PAGE_SIZE,
-                offset = (loadKey ?: 0) * PAGE_SIZE,
+                limit = state.config.pageSize,
+                offset = loadKey ?: 0,
             )
+
+            Log.d(TAG, "load: remote response = $response")
 
             database.withTransaction {
                 if (loadType == LoadType.REFRESH) {
+                    Log.i(TAG, "load: Refresh requested; cleaning all data from Pokemon")
                     pokemonWithTypeDao.clearAll()
                     pokemonDao.clearAll()
+                    remoteKeyDao.clearAll()
                 }
 
-                val result = cachePokemonListUseCase(response.results)
+                Log.d(TAG, "load: inserting/updating remote key")
+                upsertRemoteKeyUseCase(response).run {
+                    Log.d(TAG, "upsertRemoteKeyUseCase.run: upsert result = $this")
+                    if (this is UpsertRemoteKeyUseCase.Result.Failure) {
+                        throw exception
+                    }
+                }
 
-                if (result is CachePokemonListUseCase.Result.Failure) {
-                    throw result.exception
+                cachePokemonListUseCase(response.results).run {
+                    Log.d(TAG, "cachePokemonListUseCase.run: cache result = $this")
+                    if (this is CachePokemonListUseCase.Result.Failure) {
+                        throw exception
+                    }
                 }
             }
 
-            MediatorResult.Success(
-                endOfPaginationReached = response.next == null
-            )
-        } catch (e: IOException) {
-            MediatorResult.Error(e)
-        } catch (e: HttpException) {
+            val endOfPaginationReached = response.next == null
+            Log.d(TAG, "load: endOfPaginationReached = $endOfPaginationReached")
+
+            MediatorResult.Success(endOfPaginationReached)
+        } catch (e: Exception) {
+            Log.e(TAG, "load: Mediator error.", e)
             MediatorResult.Error(e)
         }
     }

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/data/paging/PokemonListRemoteMediator.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/data/paging/PokemonListRemoteMediator.kt
@@ -1,0 +1,69 @@
+package dev.tonholo.study.pokedex.data.paging
+
+import androidx.paging.ExperimentalPagingApi
+import androidx.paging.LoadType
+import androidx.paging.PagingState
+import androidx.paging.RemoteMediator
+import androidx.room.withTransaction
+import dev.tonholo.study.pokedex.data.database.AppDatabase
+import dev.tonholo.study.pokedex.data.model.PokemonEntry
+import dev.tonholo.study.pokedex.data.remote.PokeApi
+import dev.tonholo.study.pokedex.screens.pokemonList.PAGE_SIZE
+import dev.tonholo.study.pokedex.usecases.CachePokemonListUseCase
+import retrofit2.HttpException
+import java.io.IOException
+import javax.inject.Inject
+
+@ExperimentalPagingApi
+class PokemonListRemoteMediator @Inject constructor(
+    private val database: AppDatabase,
+    private val pokeApi: PokeApi,
+    private val cachePokemonListUseCase: CachePokemonListUseCase,
+) : RemoteMediator<Int, PokemonEntry>() {
+    private val pokemonDao = database.pokemonDao()
+    private val pokemonWithTypeDao = database.pokemonWithTypeDao()
+
+    override suspend fun load(
+        loadType: LoadType,
+        state: PagingState<Int, PokemonEntry>,
+    ): MediatorResult {
+        return try {
+            val loadKey = when (loadType) {
+                LoadType.REFRESH -> null
+                LoadType.PREPEND ->
+                    return MediatorResult.Success(endOfPaginationReached = true)
+                LoadType.APPEND -> {
+                    val lastItem = state.lastItemOrNull()
+                        ?: return MediatorResult.Success(endOfPaginationReached = true)
+                    lastItem.number
+                }
+            }
+
+            val response = pokeApi.getPokemonList(
+                limit = PAGE_SIZE,
+                offset = (loadKey ?: 0) * PAGE_SIZE,
+            )
+
+            database.withTransaction {
+                if (loadType == LoadType.REFRESH) {
+                    pokemonWithTypeDao.clearAll()
+                    pokemonDao.clearAll()
+                }
+
+                val result = cachePokemonListUseCase(response.results)
+
+                if (result is CachePokemonListUseCase.Result.Failure) {
+                    throw result.exception
+                }
+            }
+
+            MediatorResult.Success(
+                endOfPaginationReached = response.next == null
+            )
+        } catch (e: IOException) {
+            MediatorResult.Error(e)
+        } catch (e: HttpException) {
+            MediatorResult.Error(e)
+        }
+    }
+}

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/data/remote/responses/PokemonList.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/data/remote/responses/PokemonList.kt
@@ -2,7 +2,7 @@ package dev.tonholo.study.pokedex.data.remote.responses
 
 data class PokemonList(
     val count: Int,
-    val next: String,
-    val previous: String,
+    val next: String?,
+    val previous: String?,
     val results: List<PokemonListResult>,
 )

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/data/remote/responses/PokemonListResult.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/data/remote/responses/PokemonListResult.kt
@@ -5,3 +5,10 @@ data class PokemonListResult(
     val name: String,
     val url: String,
 )
+
+val PokemonListResult.number
+    get() = if (url.endsWith("/")) {
+        url.dropLast(1).takeLastWhile { it.isDigit() }
+    } else {
+        url.takeLastWhile { it.isDigit() }
+    }.toInt()

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/di/DatabaseModule.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/di/DatabaseModule.kt
@@ -9,6 +9,7 @@ import dagger.hilt.components.SingletonComponent
 import dev.tonholo.study.pokedex.data.dao.PokemonDao
 import dev.tonholo.study.pokedex.data.dao.PokemonTypeDao
 import dev.tonholo.study.pokedex.data.dao.PokemonWithTypeDao
+import dev.tonholo.study.pokedex.data.dao.RemoteKeyDao
 import dev.tonholo.study.pokedex.data.database.AppDatabase
 import javax.inject.Singleton
 
@@ -32,4 +33,8 @@ object DatabaseModule {
     @Provides
     fun providePokemonWithTypeDao(appDatabase: AppDatabase): PokemonWithTypeDao =
         appDatabase.pokemonWithTypeDao()
+
+    @Provides
+    fun provideRemoteKeyDao(appDatabase: AppDatabase): RemoteKeyDao =
+        appDatabase.remoteKeyDao()
 }

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/di/ViewModelModule.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/di/ViewModelModule.kt
@@ -1,0 +1,20 @@
+package dev.tonholo.study.pokedex.di
+
+import androidx.paging.ExperimentalPagingApi
+import androidx.paging.RemoteMediator
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.scopes.ViewModelScoped
+import dev.tonholo.study.pokedex.data.entity.PokemonTypePair
+import dev.tonholo.study.pokedex.data.paging.PokemonListRemoteMediator
+
+@ExperimentalPagingApi
+@Module
+@InstallIn(ViewModelComponent::class)
+interface ViewModelModule {
+    @Binds
+    @ViewModelScoped
+    fun bindRemoteMediator(pokemonListRemoteMediator: PokemonListRemoteMediator): RemoteMediator<Int, PokemonTypePair>
+}

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/screens/MainActivity.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/screens/MainActivity.kt
@@ -1,26 +1,25 @@
 package dev.tonholo.study.pokedex.screens
 
 import android.os.Bundle
-import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.core.content.ContextCompat
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import androidx.paging.ExperimentalPagingApi
 import coil.annotation.ExperimentalCoilApi
 import dagger.hilt.android.AndroidEntryPoint
-import dev.tonholo.study.pokedex.R
 import dev.tonholo.study.pokedex.screens.pokemonDetail.PokemonDetailScreen
 import dev.tonholo.study.pokedex.screens.pokemonList.PokemonListScreen
 import dev.tonholo.study.pokedex.ui.theme.PokedexAppTheme
 
+@ExperimentalPagingApi
 @ExperimentalCoilApi
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -48,7 +47,7 @@ class MainActivity : ComponentActivity() {
                             }
                         ),
                     ) {
-                        window.statusBarColor = ContextCompat.getColor(this@MainActivity, android.R.color.black)
+                        window.statusBarColor = Color.Black.toArgb()
                         val pokemonName = remember {
                             it.arguments?.getString(Routes.PokemonDetails.Params.pokemonName)
                                 ?: throw IllegalArgumentException(

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/PokemonListScreen.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/PokemonListScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -19,26 +18,20 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import androidx.paging.ExperimentalPagingApi
 import coil.annotation.ExperimentalCoilApi
 import dev.tonholo.study.pokedex.R
-import dev.tonholo.study.pokedex.data.dao.PokemonDao
-import dev.tonholo.study.pokedex.data.entity.PokemonTypePair
-import dev.tonholo.study.pokedex.data.remote.PokeApi
-import dev.tonholo.study.pokedex.data.remote.responses.Pokemon
-import dev.tonholo.study.pokedex.data.remote.responses.PokemonList
-import dev.tonholo.study.pokedex.data.remote.responses.PokemonListResult
 import dev.tonholo.study.pokedex.screens.pokemonList.components.PokemonList
 import dev.tonholo.study.pokedex.screens.pokemonList.components.SearchBar
 import dev.tonholo.study.pokedex.ui.theme.PokedexAppThemePreview
 import dev.tonholo.study.pokedex.ui.theme.state.ThemeState
 import dev.tonholo.study.pokedex.ui.theme.state.ThemeStateHandler
 import dev.tonholo.study.pokedex.ui.theme.viewModel.ThemeViewModel
-import dev.tonholo.study.pokedex.usecases.CachePokemonListUseCase
-import dev.tonholo.study.pokedex.usecases.GetPokemonListUseCase
-import kotlinx.coroutines.flow.Flow
+import dev.tonholo.study.pokedex.util.preview.stubs.getPokemonListUseCaseStub
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
+@ExperimentalPagingApi
 @ExperimentalCoilApi
 @Composable
 fun PokemonListScreen(
@@ -91,6 +84,7 @@ fun PokemonListScreen(
     }
 }
 
+@ExperimentalPagingApi
 @ExperimentalCoilApi
 @Preview
 @Composable
@@ -105,6 +99,7 @@ private fun LightThemePreview() {
     }
 }
 
+@ExperimentalPagingApi
 @ExperimentalCoilApi
 @Preview(
     showBackground = true,
@@ -138,42 +133,5 @@ private fun buildPreviewThemeViewModel(themeState: ThemeState) =
         }
     )
 
-private fun buildFakeViewModel(): PokemonListViewModel {
-    val entries = (0..100).map {
-        PokemonListResult(
-            name = "Pokemon $it",
-            url = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/$it.png",
-        )
-    }
-
-
-    return PokemonListViewModel(
-        GetPokemonListUseCase(object : PokeApi {
-            override suspend fun getPokemonList(limit: Int, offset: Int): PokemonList = with(entries) {
-                PokemonList(
-                    count = size,
-                    next = "mock",
-                    previous = "mock",
-                    results = this,
-                )
-            }
-
-            override suspend fun getPokemon(name: String): Pokemon {
-                TODO("Not yet implemented")
-            }
-        }),
-        CachePokemonListUseCase(object : PokemonDao() {
-            override fun getPokemonWithType(): Flow<List<PokemonTypePair>> {
-                TODO("Not yet implemented")
-            }
-
-            override suspend fun insert(pokemon: dev.tonholo.study.pokedex.data.entity.Pokemon): Long {
-                TODO("Not yet implemented")
-            }
-
-            override suspend fun insertAll(pokemonList: List<dev.tonholo.study.pokedex.data.entity.Pokemon>) {
-                TODO("Not yet implemented")
-            }
-        })
-    )
-}
+@ExperimentalPagingApi
+private fun buildFakeViewModel(): PokemonListViewModel = PokemonListViewModel(getPokemonListUseCaseStub)

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/PokemonListViewModel.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/PokemonListViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.ExperimentalPagingApi
 import androidx.paging.LoadState
+import androidx.paging.cachedIn
 import androidx.paging.compose.LazyPagingItems
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.tonholo.study.pokedex.data.model.PokemonEntry
@@ -28,7 +29,7 @@ class PokemonListViewModel @Inject constructor(
     val isLoading = mutableStateOf(false)
     val loadingError = mutableStateOf("")
     val isSearching = mutableStateOf(false)
-    val pokemonList = getPokemonListUseCase()
+    val pokemonList = getPokemonListUseCase().cachedIn(viewModelScope)
 
     var currentSearchingList = mutableStateOf(listOf<PokemonEntry>())
     private var cachedPokemonList = listOf<PokemonEntry>()

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/PokemonListViewModel.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/PokemonListViewModel.kt
@@ -47,7 +47,7 @@ class PokemonListViewModel @Inject constructor(
             }
             loadState.append is LoadState.Error -> {
                 isLoading.value = false
-                val loadStateError = loadState.refresh as LoadState.Error
+                val loadStateError = loadState.append as LoadState.Error
                 loadingError.value = loadStateError.error.localizedMessage ?: "Unhandled error"
             }
             loadState.refresh is LoadState.NotLoading && loadState.append is LoadState.NotLoading ->

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/PokemonListViewModel.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/PokemonListViewModel.kt
@@ -6,10 +6,16 @@ import android.graphics.drawable.Drawable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import androidx.paging.ExperimentalPagingApi
+import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.tonholo.study.pokedex.data.model.PokemonEntry
 import dev.tonholo.study.pokedex.usecases.GetPokemonListUseCase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.util.*
 import javax.inject.Inject
 
 const val PAGE_SIZE = 20
@@ -17,42 +23,66 @@ const val PAGE_SIZE = 20
 @ExperimentalPagingApi
 @HiltViewModel
 class PokemonListViewModel @Inject constructor(
-    val getPokemonListUseCase: GetPokemonListUseCase,
+    getPokemonListUseCase: GetPokemonListUseCase,
 ) : ViewModel() {
+    val isLoading = mutableStateOf(false)
     val loadingError = mutableStateOf("")
     val isSearching = mutableStateOf(false)
     val pokemonList = getPokemonListUseCase()
 
+    var currentSearchingList = mutableStateOf(listOf<PokemonEntry>())
     private var cachedPokemonList = listOf<PokemonEntry>()
 
+    fun handleLoadState(lazyPagingItems: LazyPagingItems<PokemonEntry>) {
+        if (!isSearching.value) currentSearchingList.value = lazyPagingItems.itemSnapshotList.items
+
+        val loadState = lazyPagingItems.loadState
+        when  {
+            loadState.refresh is LoadState.Loading || loadState.append is LoadState.Loading ->
+                isLoading.value = true
+            loadState.refresh is LoadState.Error -> {
+                isLoading.value = false
+                val loadStateError = loadState.refresh as LoadState.Error
+                loadingError.value = loadStateError.error.localizedMessage ?: "Unhandled error"
+            }
+            loadState.append is LoadState.Error -> {
+                isLoading.value = false
+                val loadStateError = loadState.refresh as LoadState.Error
+                loadingError.value = loadStateError.error.localizedMessage ?: "Unhandled error"
+            }
+            loadState.refresh is LoadState.NotLoading && loadState.append is LoadState.NotLoading ->
+                isLoading.value = false
+        }
+    }
+
     fun filterPokemonList(query: String) {
-//        val listToSearch = if (isSearching.value) {
-//            cachedPokemonList
-//        } else {
-//            pokemonList.value
-//        }
-//
-//        viewModelScope.launch(Dispatchers.Default) {
-//            if (query.isBlank()) {
-//                pokemonList.value = cachedPokemonList
-//                isSearching.value = false
-//                return@launch
-//            }
-//
-//            val results = listToSearch.filter {
-//                with(query.lowercase(Locale.getDefault()).trim()) {
-//                    it.pokemonName.lowercase(Locale.getDefault()).contains(this)
-//                            || it.number.toString() == this
-//                }
-//            }
-//
-//            if (!isSearching.value) {
-//                cachedPokemonList = pokemonList.value
-//                isSearching.value = true
-//            }
-//
-//            pokemonList.value = results
-//        }
+        val listToSearch = if (isSearching.value) {
+            cachedPokemonList
+        } else {
+            currentSearchingList.value
+        }
+
+        viewModelScope.launch(Dispatchers.Default) {
+            if (query.isBlank()) {
+                currentSearchingList.value = cachedPokemonList
+                isSearching.value = false
+                return@launch
+            }
+
+            val results = listToSearch.filter {
+                with(query.lowercase(Locale.getDefault()).trim()) {
+                    it.pokemonName.lowercase(Locale.getDefault()).contains(this)
+                            || it.number.toString() == this
+                }
+            }
+
+            if (!isSearching.value) {
+                cachedPokemonList = currentSearchingList.value
+                isSearching.value = true
+            }
+
+            currentSearchingList.value = results
+        }
     }
 
     fun getDominantColor(drawable: Drawable): Color {

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/PokemonListViewModel.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/PokemonListViewModel.kt
@@ -6,110 +6,53 @@ import android.graphics.drawable.Drawable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
+import androidx.paging.ExperimentalPagingApi
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.tonholo.study.pokedex.data.model.PokemonEntry
-import dev.tonholo.study.pokedex.usecases.CachePokemonDetailUseCase
-import dev.tonholo.study.pokedex.usecases.CachePokemonListUseCase
 import dev.tonholo.study.pokedex.usecases.GetPokemonListUseCase
-import dev.tonholo.study.pokedex.util.toTitleCase
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import java.util.*
 import javax.inject.Inject
 
 const val PAGE_SIZE = 20
 
+@ExperimentalPagingApi
 @HiltViewModel
 class PokemonListViewModel @Inject constructor(
     val getPokemonListUseCase: GetPokemonListUseCase,
-    val cachePokemonListUseCase: CachePokemonListUseCase,
 ) : ViewModel() {
-    private var currentPage = 0
-
-    val pokemonList = mutableStateOf<List<PokemonEntry>>(listOf())
     val loadingError = mutableStateOf("")
-    val isLoading = mutableStateOf(false)
-    val isEndReached = mutableStateOf(false)
     val isSearching = mutableStateOf(false)
+    val pokemonList = getPokemonListUseCase()
 
     private var cachedPokemonList = listOf<PokemonEntry>()
 
-    init {
-        loadPokemonListPaginated()
-    }
-
-    fun loadPokemonListPaginated() {
-        viewModelScope.launch {
-            isLoading.value = true
-            val params = GetPokemonListUseCase.Params(
-                limit = PAGE_SIZE,
-                offset = currentPage * PAGE_SIZE,
-            )
-
-            when (val result = getPokemonListUseCase(params)) {
-                is GetPokemonListUseCase.Result.Success -> {
-                    with(result.data) {
-                        isEndReached.value = currentPage * PAGE_SIZE >= count
-                        val pokedexEntries = result.data.results.map { entry ->
-                            val number = if (entry.url.endsWith("/")) {
-                                entry.url.dropLast(1).takeLastWhile { it.isDigit() }
-                            } else {
-                                entry.url.takeLastWhile { it.isDigit() }
-                            }
-
-                            val url =
-                                "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${number}.png"
-
-                            PokemonEntry(
-                                pokemonName = entry.name.toTitleCase(),
-                                imageUrl = url,
-                                number = number.toInt()
-                            )
-                        }
-
-                        // cachePokemonListUseCase(pokedexEntries)
-                        pokemonList.value += pokedexEntries
-                    }
-                    isLoading.value = false
-                    currentPage++
-                }
-                is GetPokemonListUseCase.Result.Failure -> {
-                    loadingError.value = "${result.message}\n${result.exception?.message}"
-                    isLoading.value = false
-                }
-            }
-        }
-    }
-
     fun filterPokemonList(query: String) {
-        val listToSearch = if (isSearching.value) {
-            cachedPokemonList
-        } else {
-            pokemonList.value
-        }
-
-        viewModelScope.launch(Dispatchers.Default) {
-            if (query.isBlank()) {
-                pokemonList.value = cachedPokemonList
-                isSearching.value = false
-                return@launch
-            }
-
-            val results = listToSearch.filter {
-                with(query.lowercase(Locale.getDefault()).trim()) {
-                    it.pokemonName.lowercase(Locale.getDefault()).contains(this)
-                            || it.number.toString() == this
-                }
-            }
-
-            if (!isSearching.value) {
-                cachedPokemonList = pokemonList.value
-                isSearching.value = true
-            }
-
-            pokemonList.value = results
-        }
+//        val listToSearch = if (isSearching.value) {
+//            cachedPokemonList
+//        } else {
+//            pokemonList.value
+//        }
+//
+//        viewModelScope.launch(Dispatchers.Default) {
+//            if (query.isBlank()) {
+//                pokemonList.value = cachedPokemonList
+//                isSearching.value = false
+//                return@launch
+//            }
+//
+//            val results = listToSearch.filter {
+//                with(query.lowercase(Locale.getDefault()).trim()) {
+//                    it.pokemonName.lowercase(Locale.getDefault()).contains(this)
+//                            || it.number.toString() == this
+//                }
+//            }
+//
+//            if (!isSearching.value) {
+//                cachedPokemonList = pokemonList.value
+//                isSearching.value = true
+//            }
+//
+//            pokemonList.value = results
+//        }
     }
 
     fun getDominantColor(drawable: Drawable): Color {

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/components/PokedexRow.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/components/PokedexRow.kt
@@ -25,15 +25,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
 import androidx.paging.ExperimentalPagingApi
 import coil.annotation.ExperimentalCoilApi
 import coil.compose.ImagePainter
 import coil.compose.rememberImagePainter
 import dev.tonholo.study.pokedex.R
 import dev.tonholo.study.pokedex.data.model.PokemonEntry
-import dev.tonholo.study.pokedex.screens.Routes
 import dev.tonholo.study.pokedex.screens.pokemonList.PokemonListViewModel
 import dev.tonholo.study.pokedex.ui.theme.PokedexAppThemePreview
 import dev.tonholo.study.pokedex.ui.theme.RobotoCondensed
@@ -46,24 +43,24 @@ import dev.tonholo.study.pokedex.util.toGreyscale
 fun PokedexRow(
     first: PokemonEntry,
     last: PokemonEntry?,
-    navController: NavController,
     viewModel: PokemonListViewModel = hiltViewModel(),
+    onItemClick: (entry: PokemonEntry, dominantColor: Int) -> Unit = { _, _ -> },
 ) {
     Column {
         Row {
             PokedexEntry(
                 entry = first,
-                navController = navController,
                 modifier = Modifier.weight(1f),
                 viewModel,
+                onItemClick,
             )
             Spacer(modifier = Modifier.width(16.dp))
             if (last != null) {
                 PokedexEntry(
                     entry = last,
-                    navController = navController,
                     modifier = Modifier.weight(1f),
                     viewModel,
+                    onItemClick,
                 )
             } else {
                 Spacer(modifier = Modifier.weight(1f))
@@ -78,9 +75,9 @@ fun PokedexRow(
 @Composable
 private fun PokedexEntry(
     entry: PokemonEntry,
-    navController: NavController,
     modifier: Modifier = Modifier,
     viewModel: PokemonListViewModel,
+    onItemClick: (entry: PokemonEntry, dominantColor: Int) -> Unit = { _, _ -> },
 ) {
     var colorAnimationPlayed by remember { mutableStateOf(false) }
     val defaultDominantColor = MaterialTheme.colors.surface
@@ -115,9 +112,7 @@ private fun PokedexEntry(
                 )
             )
             .clickable {
-                navController.navigate(
-                    Routes.PokemonDetails.build(entry.pokemonName, dominantColor.toArgb())
-                )
+                onItemClick(entry, dominantColor.toArgb())
             }
     ) {
         Column {
@@ -181,7 +176,6 @@ private fun PokedexEntry(
 @Composable
 private fun LightThemePreview() {
     PokedexAppThemePreview {
-        val navController = rememberNavController()
         val entries = (0..2).map {
             PokemonEntry(
                 "Pokemon $it",
@@ -195,7 +189,6 @@ private fun LightThemePreview() {
                 PokedexRow(
                     first = entries[index],
                     last = if (index + 1 >= entries.size) null else entries[index + 1],
-                    navController = navController,
                     viewModel = PokemonListViewModel(
                         getPokemonListUseCaseStub
                     ),
@@ -214,7 +207,6 @@ private fun LightThemePreview() {
 @Composable
 private fun DarkThemePreview() {
     PokedexAppThemePreview(darkTheme = true) {
-        val navController = rememberNavController()
         val entries = (0 until 4).map {
             PokemonEntry(
                 "Pokemon $it",
@@ -232,7 +224,6 @@ private fun DarkThemePreview() {
                 PokedexRow(
                     first = entries[index],
                     last = if (index + 1 >= entries.size) null else entries[index + 1],
-                    navController = navController,
                     viewModel = PokemonListViewModel(
                         getPokemonListUseCaseStub,
                     ),

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/components/PokemonList.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/components/PokemonList.kt
@@ -4,10 +4,14 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -16,7 +20,9 @@ import androidx.navigation.NavController
 import androidx.paging.ExperimentalPagingApi
 import androidx.paging.compose.collectAsLazyPagingItems
 import coil.annotation.ExperimentalCoilApi
+import dev.tonholo.study.pokedex.screens.Routes
 import dev.tonholo.study.pokedex.screens.pokemonList.PokemonListViewModel
+import kotlinx.coroutines.launch
 
 @ExperimentalPagingApi
 @ExperimentalCoilApi
@@ -28,30 +34,50 @@ fun PokemonList(
     val lazyPagingItems = viewModel.pokemonList.collectAsLazyPagingItems()
     val loadError by remember { viewModel.loadingError }
     val isSearching by remember { viewModel.isSearching }
+    val isLoading by remember { viewModel.isLoading }
+    val currentSearchingList by remember { viewModel.currentSearchingList }
+    val coroutineScope = rememberCoroutineScope()
+    val listState = rememberLazyListState()
 
-    LazyColumn(contentPadding = PaddingValues(16.dp)) {
+    LazyColumn(
+        contentPadding = PaddingValues(16.dp),
+        state = listState,
+    ) {
         for (index in 0 until lazyPagingItems.itemCount step 2) {
             item {
-                lazyPagingItems[index]?.let { first ->
+                val (firstEntry, secondEntry) = if (isSearching) {
+                    currentSearchingList.elementAtOrNull(index) to currentSearchingList.elementAtOrNull(index + 1)
+                } else {
+                    lazyPagingItems[index] to lazyPagingItems[index + 1]
+                }
+
+                firstEntry?.let { first ->
                     PokedexRow(
                         first = first,
-                        last = lazyPagingItems[index + 1],
-                        navController = navController,
-                    )
+                        last = secondEntry,
+                    ) { entry, dominantColor ->
+                        coroutineScope.launch {
+                            listState.scrollToItem(index)
+                        }
+                        navController.navigate(
+                            Routes.PokemonDetails.build(entry.pokemonName, dominantColor)
+                        )
+                    }
                 }
             }
         }
     }
 
+    viewModel.handleLoadState(lazyPagingItems)
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier.fillMaxSize(),
     ) {
-//        if (isLoading) {
-//            CircularProgressIndicator(
-//                color = MaterialTheme.colors.primary,
-//            )
-//        }
+        if (isLoading) {
+            CircularProgressIndicator(
+                color = MaterialTheme.colors.primary,
+            )
+        }
 
         if (loadError.isNotBlank()) {
             Text(

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/components/PokemonList.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/screens/pokemonList/components/PokemonList.kt
@@ -4,47 +4,41 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import androidx.paging.ExperimentalPagingApi
+import androidx.paging.compose.collectAsLazyPagingItems
 import coil.annotation.ExperimentalCoilApi
 import dev.tonholo.study.pokedex.screens.pokemonList.PokemonListViewModel
 
+@ExperimentalPagingApi
 @ExperimentalCoilApi
 @Composable
 fun PokemonList(
     navController: NavController,
     viewModel: PokemonListViewModel = hiltViewModel(),
 ) {
-    val pokemonList by remember { viewModel.pokemonList }
-    val isEndReached by remember { viewModel.isEndReached }
+    val lazyPagingItems = viewModel.pokemonList.collectAsLazyPagingItems()
     val loadError by remember { viewModel.loadingError }
-    val isLoading by remember { viewModel.isLoading }
     val isSearching by remember { viewModel.isSearching }
 
     LazyColumn(contentPadding = PaddingValues(16.dp)) {
-        with(pokemonList) {
-            val itemCount = if (size % 2 == 0) {
-                size / 2
-            } else {
-                size / 2 + 1
-            }
-            items(itemCount) {
-                if (it >= itemCount - 1 && !isEndReached && !isLoading && !isSearching) {
-                    viewModel.loadPokemonListPaginated()
+        for (index in 0 until lazyPagingItems.itemCount step 2) {
+            item {
+                lazyPagingItems[index]?.let { first ->
+                    PokedexRow(
+                        first = first,
+                        last = lazyPagingItems[index + 1],
+                        navController = navController,
+                    )
                 }
-                PokedexRow(
-                    rowIndex = it,
-                    entries = this@with,
-                    navController = navController,
-                    viewModel = viewModel
-                )
             }
         }
     }
@@ -53,11 +47,11 @@ fun PokemonList(
         contentAlignment = Alignment.Center,
         modifier = Modifier.fillMaxSize(),
     ) {
-        if (isLoading) {
-            CircularProgressIndicator(
-                color = MaterialTheme.colors.primary,
-            )
-        }
+//        if (isLoading) {
+//            CircularProgressIndicator(
+//                color = MaterialTheme.colors.primary,
+//            )
+//        }
 
         if (loadError.isNotBlank()) {
             Text(

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/usecases/CachePokemonListUseCase.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/usecases/CachePokemonListUseCase.kt
@@ -2,36 +2,41 @@ package dev.tonholo.study.pokedex.usecases
 
 import dev.tonholo.study.pokedex.data.dao.PokemonDao
 import dev.tonholo.study.pokedex.data.entity.Pokemon
-import dev.tonholo.study.pokedex.data.model.PokemonEntry
+import dev.tonholo.study.pokedex.data.remote.responses.PokemonListResult
 import dev.tonholo.study.pokedex.usecases.base.UseCase
 import javax.inject.Inject
 
 class CachePokemonListUseCase @Inject constructor(
     private val pokemonDao: PokemonDao,
-) : UseCase<List<PokemonEntry>, CachePokemonListUseCase.Result>() {
+) : UseCase<List<PokemonListResult>, CachePokemonListUseCase.Result>() {
 
     sealed class Result {
         object Success : Result()
         data class Failure(val message: String, val exception: Throwable) : Result()
     }
 
-    override suspend fun invoke(requestParams: List<PokemonEntry>): Result {
-        return try {
-            pokemonDao.insertAll(
-                requestParams.map { entry ->
-                    Pokemon(
-                        number = entry.number,
-                        name = entry.pokemonName,
-                        spriteUrl = entry.imageUrl,
-                    )
+    override suspend fun invoke(requestParams: List<PokemonListResult>): Result = try {
+        pokemonDao.insertAll(
+            requestParams.map { entry ->
+                val number = if (entry.url.endsWith("/")) {
+                    entry.url.dropLast(1).takeLastWhile { it.isDigit() }
+                } else {
+                    entry.url.takeLastWhile { it.isDigit() }
                 }
-            )
-            Result.Success
-        } catch (e: Exception) {
-            Result.Failure(
-                message = e.localizedMessage ?: "Unhandled error",
-                exception = e,
-            )
-        }
+                val spriteUrl =
+                    "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${number}.png"
+                Pokemon(
+                    number = number.toInt(),
+                    name = entry.name,
+                    spriteUrl = spriteUrl,
+                )
+            }
+        )
+        Result.Success
+    } catch (e: Exception) {
+        Result.Failure(
+            message = e.localizedMessage ?: "Unhandled error",
+            exception = e,
+        )
     }
 }

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/usecases/CachePokemonListUseCase.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/usecases/CachePokemonListUseCase.kt
@@ -3,7 +3,9 @@ package dev.tonholo.study.pokedex.usecases
 import dev.tonholo.study.pokedex.data.dao.PokemonDao
 import dev.tonholo.study.pokedex.data.entity.Pokemon
 import dev.tonholo.study.pokedex.data.remote.responses.PokemonListResult
+import dev.tonholo.study.pokedex.data.remote.responses.number
 import dev.tonholo.study.pokedex.usecases.base.UseCase
+import dev.tonholo.study.pokedex.util.toTitleCase
 import javax.inject.Inject
 
 class CachePokemonListUseCase @Inject constructor(
@@ -18,16 +20,12 @@ class CachePokemonListUseCase @Inject constructor(
     override suspend fun invoke(requestParams: List<PokemonListResult>): Result = try {
         pokemonDao.insertAll(
             requestParams.map { entry ->
-                val number = if (entry.url.endsWith("/")) {
-                    entry.url.dropLast(1).takeLastWhile { it.isDigit() }
-                } else {
-                    entry.url.takeLastWhile { it.isDigit() }
-                }
+                val number = entry.number
                 val spriteUrl =
                     "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${number}.png"
                 Pokemon(
-                    number = number.toInt(),
-                    name = entry.name,
+                    number = number,
+                    name = entry.name.toTitleCase(),
                     spriteUrl = spriteUrl,
                 )
             }

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/usecases/UpsertRemoteKeyUseCase.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/usecases/UpsertRemoteKeyUseCase.kt
@@ -1,0 +1,37 @@
+package dev.tonholo.study.pokedex.usecases
+
+import android.net.Uri
+import dev.tonholo.study.pokedex.data.dao.RemoteKeyDao
+import dev.tonholo.study.pokedex.data.entity.RemoteKey
+import dev.tonholo.study.pokedex.data.remote.responses.PokemonList
+import dev.tonholo.study.pokedex.data.remote.responses.number
+import dev.tonholo.study.pokedex.usecases.base.UseCase
+import javax.inject.Inject
+
+class UpsertRemoteKeyUseCase @Inject constructor(
+    private val remoteKeyDao: RemoteKeyDao,
+): UseCase<PokemonList, UpsertRemoteKeyUseCase.Result>() {
+    sealed class Result {
+        object Success : Result()
+        data class Failure(val message: String, val exception: Throwable) : Result()
+    }
+
+    override suspend fun invoke(requestParams: PokemonList): Result = try {
+        requestParams.run {
+            val nextKey = next?.let {
+                Uri.parse(it).getQueryParameter("offset")?.toInt()
+            }
+
+            remoteKeyDao.upsert(RemoteKey(
+                pokemonNumber = results.last().number,
+                nextKey = nextKey,
+            ))
+        }
+        Result.Success
+    } catch (e: Exception) {
+        Result.Failure(
+            message = e.localizedMessage ?: "Unhandled error",
+            exception = e,
+        )
+    }
+}

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/usecases/base/UseCase.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/usecases/base/UseCase.kt
@@ -3,3 +3,7 @@ package dev.tonholo.study.pokedex.usecases.base
 abstract class UseCase<in TRequest, out TResponse> {
     abstract suspend operator fun invoke(requestParams: TRequest): TResponse
 }
+
+abstract class UseCaseWithoutParamsSync<out TResponse> {
+    abstract operator fun invoke(): TResponse
+}

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/util/DrawableExtensions.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/util/DrawableExtensions.kt
@@ -1,0 +1,12 @@
+package dev.tonholo.study.pokedex.util
+
+import android.graphics.ColorMatrix
+import android.graphics.ColorMatrixColorFilter
+import android.graphics.drawable.Drawable
+
+fun Drawable.toGreyscale() {
+    mutate()
+    val matrix = ColorMatrix().apply { setSaturation(0F) }
+    val filter = ColorMatrixColorFilter(matrix)
+    colorFilter = filter
+}

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/util/preview/stubs/GetPokemonListUseCaseStub.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/util/preview/stubs/GetPokemonListUseCaseStub.kt
@@ -1,0 +1,11 @@
+package dev.tonholo.study.pokedex.util.preview.stubs
+
+import androidx.paging.ExperimentalPagingApi
+import dev.tonholo.study.pokedex.usecases.GetPokemonListUseCase
+
+@ExperimentalPagingApi
+val getPokemonListUseCaseStub =
+    GetPokemonListUseCase(
+        RemoteMediatorStub,
+        StubPokemonDao
+    )

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/util/preview/stubs/RemoteMediatorStub.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/util/preview/stubs/RemoteMediatorStub.kt
@@ -1,0 +1,14 @@
+package dev.tonholo.study.pokedex.util.preview.stubs
+
+import androidx.paging.ExperimentalPagingApi
+import androidx.paging.LoadType
+import androidx.paging.PagingState
+import androidx.paging.RemoteMediator
+import dev.tonholo.study.pokedex.data.entity.PokemonTypePair
+
+@ExperimentalPagingApi
+object RemoteMediatorStub : RemoteMediator<Int, PokemonTypePair>() {
+    override suspend fun load(loadType: LoadType, state: PagingState<Int, PokemonTypePair>): MediatorResult {
+        TODO("Not yet implemented")
+    }
+}

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/util/preview/stubs/StubPokemonApi.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/util/preview/stubs/StubPokemonApi.kt
@@ -1,0 +1,15 @@
+package dev.tonholo.study.pokedex.util.preview.stubs
+
+import dev.tonholo.study.pokedex.data.remote.PokeApi
+import dev.tonholo.study.pokedex.data.remote.responses.Pokemon
+import dev.tonholo.study.pokedex.data.remote.responses.PokemonList
+
+object StubPokemonApi : PokeApi {
+    override suspend fun getPokemonList(limit: Int, offset: Int): PokemonList {
+        throw NotImplementedError()
+    }
+
+    override suspend fun getPokemon(name: String): Pokemon {
+        throw NotImplementedError()
+    }
+}

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/util/preview/stubs/StubPokemonDao.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/util/preview/stubs/StubPokemonDao.kt
@@ -1,0 +1,29 @@
+package dev.tonholo.study.pokedex.util.preview.stubs
+
+import androidx.paging.PagingSource
+import dev.tonholo.study.pokedex.data.dao.PokemonDao
+import dev.tonholo.study.pokedex.data.entity.Pokemon
+import dev.tonholo.study.pokedex.data.entity.PokemonTypePair
+import kotlinx.coroutines.flow.Flow
+
+object StubPokemonDao : PokemonDao {
+    override fun getPokemonWithType(): PagingSource<Int, PokemonTypePair> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun insert(pokemon: Pokemon): Long {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun insertAll(pokemonList: List<Pokemon>) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun clearAll() {
+        TODO("Not yet implemented")
+    }
+
+    override fun lastUpdated(): Long {
+        TODO("Not yet implemented")
+    }
+}

--- a/code/app/src/main/java/dev/tonholo/study/pokedex/util/preview/stubs/StubPokemonDao.kt
+++ b/code/app/src/main/java/dev/tonholo/study/pokedex/util/preview/stubs/StubPokemonDao.kt
@@ -23,7 +23,7 @@ object StubPokemonDao : PokemonDao {
         TODO("Not yet implemented")
     }
 
-    override fun lastUpdated(): Long {
+    override suspend fun lastUpdated(): Long {
         TODO("Not yet implemented")
     }
 }

--- a/code/buildSrc/src/main/java/dev/tonholo/pokedex/buildsrc/Dependencies.kt
+++ b/code/buildSrc/src/main/java/dev/tonholo/pokedex/buildsrc/Dependencies.kt
@@ -69,11 +69,18 @@ object Dependencies {
             const val compose = "androidx.navigation:navigation-compose:2.4.0-rc01"
         }
 
+        object Paging {
+            private const val version = "3.1.0"
+            const val runtime = "androidx.paging:paging-runtime:$version"
+            const val compose = "androidx.paging:paging-compose:1.0.0-alpha14"
+        }
+
         object Room {
             private const val version = "2.4.0"
             const val runtime = "androidx.room:room-runtime:$version"
             const val ksp = "androidx.room:room-compiler:$version"
             const val coroutines = "androidx.room:room-ktx:$version"
+            const val paging = "androidx.room:room-paging:$version"
         }
     }
 

--- a/code/buildSrc/src/main/java/dev/tonholo/pokedex/buildsrc/Dependencies.kt
+++ b/code/buildSrc/src/main/java/dev/tonholo/pokedex/buildsrc/Dependencies.kt
@@ -6,7 +6,7 @@ object Dependencies {
     }
 
     object ClassPath {
-        const val androidGradlePlugin = "com.android.tools.build:gradle:7.0.4"
+        const val androidGradlePlugin = "com.android.tools.build:gradle:7.1.0"
         const val kotlinPlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Kotlin.version}"
         const val hiltPlugin = "com.google.dagger:hilt-android-gradle-plugin:${Jetpack.Hilt.version}"
     }

--- a/code/gradle/wrapper/gradle-wrapper.properties
+++ b/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Jan 08 19:18:21 BRT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
# Background
Here is a solution for getting the data, paginated, from the database and if no data are remaining, request more data from remote and cache them.
That PR is part of the #1 issue

# Solution
To achieve the solution it was used Jetpack Paging 3 library.

# Pros
- No Pagination logic is needed to actual paginate. Jetpack Paging 3 library handles that under the hoot pretty well (Magic)
- After the UI/ViewModel changes, the code sounds way cleaner on those sides
- The list filter using the database sounds pretty simple, just need to pass the query to RemoteMediator / Room and everything will work for free. In the previous solution, I needed to cache the current list in another list and handle when it is searching or not
- The logic to request data from the database and from the remote is pretty simple. Just need to implement the `RemoteMediator` with the logic of requesting data from remote and `Room` takes care of the database part for free.

# Cons
- Lots of changes on the UI side, but I would say that it is a big con since the UI and ViewModel became way simpler after the implementation of RemoteMediator
- Handling the loading state of the pagination is quite weird. On the internet, usually, they handle that logic on the UI side but feels ugly in my opinion, so I've created a method in the ViewModel to handle that. Must have a better way to do that.

# Known bug
Search is a little bit buggy with the current solution. To fix that I would need to implement searching over the database, which is the ideal scenario, but didn't implement that here since it is not the focus.